### PR TITLE
Use int instead of eval and in a try except.

### DIFF
--- a/obd_sensors.py
+++ b/obd_sensors.py
@@ -23,7 +23,10 @@
 ###########################################################################
 
 def hex_to_int(str):
-    i = eval("0x" + str, {}, {})
+    try:
+        i = int("0x" + str, 16)
+    except:
+        return 0
     return i
 
 def maf(code):

--- a/pyobd
+++ b/pyobd
@@ -357,7 +357,7 @@ class MyApp(wx.App):
         else:
           self.configfilepath=os.environ['HOME']+'/.pyobdrc'
         if self.config.read(self.configfilepath)==[]:
-          self.COMPORT="/dev/ttyACM0"
+          self.COMPORT="/dev/ttyUSB0"
           self.RECONNATTEMPTS=5
           self.SERTIMEOUT=2
         else:


### PR DESCRIPTION
. My clio 3 1.2 16v (2005) seems to send blank str sometime which prevent any reading of DTC
